### PR TITLE
RND console unlocker

### DIFF
--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -432,7 +432,7 @@
 	req_access = list(ACCESS_RESEARCH) // Research access is required to toggle the lock.
 
 	var/silence_announcements = FALSE
-	var/locked = TRUE
+	var/locked = FALSE
 
 // An unlocked subtype of the board for mapping.
 /obj/item/circuitboard/computer/rdconsole/unlocked

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -432,7 +432,7 @@
 	req_access = list(ACCESS_RESEARCH) // Research access is required to toggle the lock.
 
 	var/silence_announcements = FALSE
-	var/locked = FALSE //lumos edit so we can research stuff
+	var/locked = FALSE //lumos edit so we can research stuff.
 
 // An unlocked subtype of the board for mapping.
 /obj/item/circuitboard/computer/rdconsole/unlocked

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -432,7 +432,7 @@
 	req_access = list(ACCESS_RESEARCH) // Research access is required to toggle the lock.
 
 	var/silence_announcements = FALSE
-	var/locked = FALSE #lumos edit to just set to false.
+	var/locked = FALSE //lumos edit so we can research stuff.
 
 // An unlocked subtype of the board for mapping.
 /obj/item/circuitboard/computer/rdconsole/unlocked

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -432,7 +432,7 @@
 	req_access = list(ACCESS_RESEARCH) // Research access is required to toggle the lock.
 
 	var/silence_announcements = FALSE
-	var/locked = FALSE //lumos edit so we can research stuff.
+	var/locked = FALSE //lumos edit so we can research stuff
 
 // An unlocked subtype of the board for mapping.
 /obj/item/circuitboard/computer/rdconsole/unlocked

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -432,7 +432,7 @@
 	req_access = list(ACCESS_RESEARCH) // Research access is required to toggle the lock.
 
 	var/silence_announcements = FALSE
-	var/locked = FALSE #lumos edit to just set to false
+	var/locked = FALSE #lumos edit to just set to false.
 
 // An unlocked subtype of the board for mapping.
 /obj/item/circuitboard/computer/rdconsole/unlocked

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -432,7 +432,7 @@
 	req_access = list(ACCESS_RESEARCH) // Research access is required to toggle the lock.
 
 	var/silence_announcements = FALSE
-	var/locked = FALSE #lumos edit to just set to false.
+	var/locked = FALSE #lumos edit to just set to false. 
 
 // An unlocked subtype of the board for mapping.
 /obj/item/circuitboard/computer/rdconsole/unlocked

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -432,7 +432,7 @@
 	req_access = list(ACCESS_RESEARCH) // Research access is required to toggle the lock.
 
 	var/silence_announcements = FALSE
-	var/locked = FALSE
+	var/locked = FALSE #lumos edit to just set to false.
 
 // An unlocked subtype of the board for mapping.
 /obj/item/circuitboard/computer/rdconsole/unlocked

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -431,8 +431,10 @@
 	build_path = /obj/machinery/computer/rdconsole
 	req_access = list(ACCESS_RESEARCH) // Research access is required to toggle the lock.
 
+//LUMOS EDIT - CHANGE - START
 	var/silence_announcements = FALSE
-	var/locked = FALSE //lumos edit so we can research stuff.
+	var/locked = FALSE
+//LUMOS EDIT - CHANGE - END
 
 // An unlocked subtype of the board for mapping.
 /obj/item/circuitboard/computer/rdconsole/unlocked

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -432,7 +432,7 @@
 	req_access = list(ACCESS_RESEARCH) // Research access is required to toggle the lock.
 
 	var/silence_announcements = FALSE
-	var/locked = FALSE #lumos edit to just set to false.
+	var/locked = FALSE #lumos edit to just set to false so we can research things.
 
 // An unlocked subtype of the board for mapping.
 /obj/item/circuitboard/computer/rdconsole/unlocked

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -431,10 +431,8 @@
 	build_path = /obj/machinery/computer/rdconsole
 	req_access = list(ACCESS_RESEARCH) // Research access is required to toggle the lock.
 
-//LUMOS EDIT - CHANGE - START
 	var/silence_announcements = FALSE
-	var/locked = FALSE
-//LUMOS EDIT - CHANGE - END
+	var/locked = FALSE //lumos edit so we can research stuff.
 
 // An unlocked subtype of the board for mapping.
 /obj/item/circuitboard/computer/rdconsole/unlocked

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -432,7 +432,7 @@
 	req_access = list(ACCESS_RESEARCH) // Research access is required to toggle the lock.
 
 	var/silence_announcements = FALSE
-	var/locked = FALSE #lumos edit to just set to false so we can research things.
+	var/locked = FALSE //lumos edit to just set to false so we can research things.
 
 // An unlocked subtype of the board for mapping.
 /obj/item/circuitboard/computer/rdconsole/unlocked

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -432,7 +432,7 @@
 	req_access = list(ACCESS_RESEARCH) // Research access is required to toggle the lock.
 
 	var/silence_announcements = FALSE
-	var/locked = FALSE #lumos edit to just set to false.
+	var/locked = FALSE #lumos edit to just set to false
 
 // An unlocked subtype of the board for mapping.
 /obj/item/circuitboard/computer/rdconsole/unlocked

--- a/modular_skyrat/modules/cargo/code/goodies.dm
+++ b/modular_skyrat/modules/cargo/code/goodies.dm
@@ -40,6 +40,15 @@
 	access_view = ACCESS_ENGINE_EQUIP
 	contains = list(/obj/item/construction/rcd/improved)
 
+	// Lumos addition start	
+/datum/supply_pack/goody/frontier_colonist
+	name = "frontier hazard protective MODsuit"
+	desc = "An unusual design of suit, in reality being no more than a slim underlayer with a built in coat and sealed helmet."
+	cost = PAYCHECK_COMMAND * 5 //500$
+	contains = list(
+		/obj/item/mod/control/pre_equipped/frontier_colonist,
+	)
+	// Lumos addition end	
 /*
 *	MISC
 */

--- a/modular_skyrat/modules/kahraman_equipment/code/clothing/mod.dm
+++ b/modular_skyrat/modules/kahraman_equipment/code/clothing/mod.dm
@@ -1,7 +1,4 @@
 // Its modsuiting time
-//Im taking ideas out of iris station and cramming it in here such as making this suit actually decent to use
-
-
 
 /datum/mod_theme/frontier_colonist
 	name = "frontier hazard protective"
@@ -19,13 +16,12 @@
 	resistance_flags = FIRE_PROOF
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
-	complexity_max = DEFAULT_MAX_COMPLEXITY - 8 //lumos edit
-	charge_drain = DEFAULT_CHARGE_DRAIN * 1.3 //lumos edit
-	slowdown_deployed = 0 //lumos edit
-	slot_flags = ITEM_SLOT_BELT //lumos edit
+	complexity_max = DEFAULT_MAX_COMPLEXITY - 7
+	charge_drain = DEFAULT_CHARGE_DRAIN * 2
+	slowdown_deployed = 1
 	inbuilt_modules = list(
-		/obj/item/mod/module/storage/belt, //its not a backpack anymore but a belt suit //lumos edit
-		/obj/item/mod/module/joint_torsion/permanent //lumos edit.
+		/obj/item/mod/module/plate_compression/permanent,
+		/obj/item/mod/module/joint_torsion/permanent
 	)
 	allowed_suit_storage = list(
 		/obj/item/ammo_box,
@@ -43,7 +39,7 @@
 		/obj/item/resonator,
 		/obj/item/t_scanner,
 		/obj/item/analyzer,
-		/obj/item/storage/medkit, //lumos edit
+		/obj/item/storage/medkit,
 	)
 	variants = list(
 		"colonist" = list(

--- a/modular_skyrat/modules/kahraman_equipment/code/clothing/mod.dm
+++ b/modular_skyrat/modules/kahraman_equipment/code/clothing/mod.dm
@@ -1,4 +1,7 @@
 // Its modsuiting time
+//Im taking ideas out of iris station and cramming it in here such as making this suit actually decent to use
+
+
 
 /datum/mod_theme/frontier_colonist
 	name = "frontier hazard protective"
@@ -16,12 +19,13 @@
 	resistance_flags = FIRE_PROOF
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
-	complexity_max = DEFAULT_MAX_COMPLEXITY - 7
-	charge_drain = DEFAULT_CHARGE_DRAIN * 2
-	slowdown_deployed = 1
+	complexity_max = DEFAULT_MAX_COMPLEXITY - 8 //lumos edit
+	charge_drain = DEFAULT_CHARGE_DRAIN * 1.3 //lumos edit
+	slowdown_deployed = 0 //lumos edit
+	slot_flags = ITEM_SLOT_BELT //lumos edit
 	inbuilt_modules = list(
-		/obj/item/mod/module/plate_compression/permanent,
-		/obj/item/mod/module/joint_torsion/permanent
+		/obj/item/mod/module/storage/belt, //its not a backpack anymore but a belt suit //lumos edit
+		/obj/item/mod/module/joint_torsion/permanent //lumos edit
 	)
 	allowed_suit_storage = list(
 		/obj/item/ammo_box,
@@ -39,7 +43,7 @@
 		/obj/item/resonator,
 		/obj/item/t_scanner,
 		/obj/item/analyzer,
-		/obj/item/storage/medkit,
+		/obj/item/storage/medkit, //lumos edit
 	)
 	variants = list(
 		"colonist" = list(

--- a/modular_skyrat/modules/kahraman_equipment/code/clothing/mod.dm
+++ b/modular_skyrat/modules/kahraman_equipment/code/clothing/mod.dm
@@ -25,7 +25,7 @@
 	slot_flags = ITEM_SLOT_BELT //lumos edit
 	inbuilt_modules = list(
 		/obj/item/mod/module/storage/belt, //its not a backpack anymore but a belt suit //lumos edit
-		/obj/item/mod/module/joint_torsion/permanent //lumos edit
+		/obj/item/mod/module/joint_torsion/permanent //lumos edit.
 	)
 	allowed_suit_storage = list(
 		/obj/item/ammo_box,

--- a/modular_skyrat/modules/simple_research/research_document.dm
+++ b/modular_skyrat/modules/simple_research/research_document.dm
@@ -6,7 +6,7 @@
 		/obj/item/stack/sheet/cloth = 4,
 	)
 	category = CAT_TOOLS
-	crafting_flags = CRAFT_MUST_BE_LEARNED
+	#crafting_flags = CRAFT_MUST_BE_LEARNED ///Lumos edit, lets everyone be able to actually craft this thing since you cant learn how to
 
 /obj/item/research_paper
 	name = "research paper"


### PR DESCRIPTION
The syndicate have given us their keygen to remove the RND console DRM so we can actually research things even in the deep depths of space, station or on any new RND consoles.
